### PR TITLE
Remove cogs I am no longer hosting.

### DIFF
--- a/cogs/discemote2.json
+++ b/cogs/discemote2.json
@@ -1,6 +1,0 @@
-{
-    "title": "discemote2",
-    "description": "Tools for dumping, and collecting statistics regarding, custom server emotes.",
-    "author": "HarJIT",
-    "link": "http://harjit.moe/discord/cogs/discemote2/discemote2.py"
-}

--- a/cogs/imagepump.json
+++ b/cogs/imagepump.json
@@ -1,6 +1,0 @@
-{
-    "title": "imagepump",
-    "description": "Opposite of imagedump: upload images from a directory. Please only use in servers/channels which permit posting such a series of images.",
-    "author": "HarJIT",
-    "link": "http://harjit.moe/discord/cogs/imagepump/imagepump.py"
-}

--- a/cogs/listroles.json
+++ b/cogs/listroles.json
@@ -1,6 +1,0 @@
-{
-    "title": "listroles",
-    "description": "List roles on a server by number of members.",
-    "author": "HarJIT",
-    "link": "http://harjit.moe/discord/cogs/listroles/listroles.py"
-}


### PR DESCRIPTION
Out of what I feel is meet precaution with regard to Discord's recent crackdown, I have expunged my cogs from my website. Their links will no longer work. I am sorry about this, but if Discord have shifted to putting the letter of the law above its root principle, I see no other course of action.