### PR TITLE
Mentionbomb

### DIFF
--- a/cogs/mentionbomb.json
+++ b/cogs/mentionbomb.json
@@ -1,0 +1,6 @@
+{
+    "title": "mentionbomb",
+    "description": "Poor mans @everyone: Mentions everyone without using @everyone",
+    "author": "Marc3842h",
+    "link": "https://gist.githubusercontent.com/Marc3842h/d6eaee8340f28d4cdd59b09c1c03f409/raw/mentionbomb.py"
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24739711/35737377-8d82e8f8-082b-11e8-93cb-0f50a981e5f3.png)

I'm not even sure if this will get accepted but I found it fun to fuck with friends that think removing the `@everyone` permission from me could change anything >:).

Most public bots that have moderation features automatically remove the message so public servers aren't much at risk.